### PR TITLE
removed code that creates module PDF links

### DIFF
--- a/Products/RhaptosContent/skins/rhaptos_content/bar_content_actions.pt
+++ b/Products/RhaptosContent/skins/rhaptos_content/bar_content_actions.pt
@@ -109,13 +109,6 @@
           <h3 class="ca_header" 
               i18n:translate="text_menu_header_module">Download module as:</h3>
           <ul class="ca_list">
-            <li class="ca_list_item ca_pdf">
-              <a href="#" onmousedown="try{var t=_gat._getTracker('UA-7903479-1'); t._initData(); t._setDomainName('.cnx.org'); t._trackPageview(window.location.pathname+'?event=module:download:pdf', 0);}catch(err){}"
-                 tal:attributes="href modulepdf"
-                 i18n:translate="text_PDF">
-                PDF
-              </a>
-            </li>
             <li class="ca_list_item ca_epub"
                 tal:condition="moduleepub">
               <a href="#" onmousedown="try{var t=_gat._getTracker('UA-7903479-1'); t._initData(); t._setDomainName('.cnx.org'); t._trackPageview(window.location.pathname+'?event=module:download:epub', 0);}catch(err){}"

--- a/Products/RhaptosContent/skins/rhaptos_content/bar_content_actions_view.py
+++ b/Products/RhaptosContent/skins/rhaptos_content/bar_content_actions_view.py
@@ -24,9 +24,6 @@ ptool = getToolByName(context, 'rhaptos_print')
 dls = {}
 
 if module:
-    pdflatextool = getToolByName(context, 'portal_pdflatex', None)
-    url = "%s/content/%s/%s/?format=pdf" % (portal_url, module.objectId, module.version)
-    dls['modulepdf'] = pdflatextool and url or None
     epubable = ptool.doesFileExist(module.objectId, module.version, 'epub')
     url = "%s/content/%s/%s/?format=epub" % (portal_url, module.objectId, module.version)
     dls['moduleepub'] = epubable and url or None

--- a/Products/RhaptosContent/skins/rhaptos_content/bottom_content_actions.pt
+++ b/Products/RhaptosContent/skins/rhaptos_content/bottom_content_actions.pt
@@ -262,11 +262,6 @@
         <tal:module tal:condition="downloadmod">
           <h4 tal:condition="downloadboth" 
               i18n:translate="label_module_as">Module as:</h4>
-          <tal:pdf tal:condition="modulepdf">
-            <a href="#" i18n:translate="text_module_pdf" onmousedown="try{var t=_gat._getTracker('UA-7903479-1'); t._initData(); t._setDomainName('.cnx.org'); t._trackPageview(window.location.pathname+'?event=module:download:pdf', 100);}catch(err){}"
-              tal:attributes="href modulepdf">PDF</a>
-            |
-          </tal:pdf>
           <tal:epub tal:condition="moduleepub">
             <a href="#" i18n:translate="text_module_epub" onmousedown="try{var t=_gat._getTracker('UA-7903479-1'); t._initData(); t._setDomainName('.cnx.org'); t._trackPageview(window.location.pathname+'?event=module:download:epub', 100);}catch(err){}"
               tal:attributes="href moduleepub">EPUB</a>

--- a/Products/RhaptosContent/skins/rhaptos_content/content_info.pt
+++ b/Products/RhaptosContent/skins/rhaptos_content/content_info.pt
@@ -323,21 +323,6 @@
             tal:condition="python:isPublic and inModule">
         <h2 id="cnx_downloads_header" class="section-header" i18n:translate="heading_downloads_section">Downloads</h2>
         <table>
-          <tr>
-            <td valign="top" class="cnx_before" i18n:translate="label_downloads_module_pdf">PDF:</td>
-            <td valign="top">
-              <a href="module_export?format=zip" onmousedown="try{var t=_gat._getTracker('UA-7903479-1'); t._initData(); t._setDomainName('.cnx.org'); t._trackPageview(window.location.pathname+'?event=module:download:pdf');}catch(err){}"
-                 tal:attributes="href string:${realcontexturl}?format=pdf"
-                 tal:content="string:${objectId}_${version}.pdf">m9001_2.15.pdf</a>
-            </td>
-            <td valign="top">
-              <span i18n:translate="help_downloads_module_pdf">
-                PDF file, for viewing content offline and printing. 
-              </span>
-              <a href="/help/viewing/downloads#pdf"
-                 i18n:translate="label_learn_more">Learn more</a>.
-            </td>
-          </tr>
           <tal:row tal:condition="doesEpubExist">
             <tr>
               <td valign="top" class="cnx_before" i18n:translate="label_downloads_module_epub">EPUB:</td>


### PR DESCRIPTION
Links removed are in Downloads dropdown, at the bottom of content and on the metadata page.
